### PR TITLE
Fix: Convert mac to lower case

### DIFF
--- a/orvibo.coffee
+++ b/orvibo.coffee
@@ -54,7 +54,7 @@ module.exports = (env) ->
       @name = @config.name
       @id = @config.id
       @ip = @config.ip
-      @mac = @config.mac
+      @mac = (@config.mac || "").toLowerCase().trim()
       @interval = 1000 * @config.interval
 
       #as we are subscribed the socket will also notify us about all powerstate changes


### PR DESCRIPTION
Your implementation expects hex characteristics to be lower case, however, some tools as "s20.exe" provide the mac address with upper case characters. Converting it to lower case to make it it case insensitive. Using trim() to remove whitespace from both sides of the string which may get copied when copy-pasting the mac address.
